### PR TITLE
Hotfix metabat & antismash

### DIFF
--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -487,8 +487,10 @@ rule binning_perSample:
 	log:
 		"logs/MAGs/PerSample/metabat.log"
 	threads: config['threads_metabat']
+	params:
+		bin_size = config['metabat_bin_size']
 	shell:
-		"bash workflow/scripts/snakemake_metabat_sample.sh {threads}"
+		"bash workflow/scripts/snakemake_metabat_sample.sh {threads} {params.bin_size}"
 
 # rule binning_perCohort bins the contigs into MAGs for the per-cohort assembly
 rule binning_perCohort:
@@ -497,8 +499,10 @@ rule binning_perCohort:
 	log:
 		"logs/MAGs/PerCohort/metabat.log"
 	threads: config['threads_metabat']
+	params:
+		bin_size = config['metabat_bin_size']
 	shell:
-		"bash workflow/scripts/snakemake_metabat_cohort.sh {threads}"
+		"bash workflow/scripts/snakemake_metabat_cohort.sh {threads} {params.bin_size}"
 
 
 # quality checking of the assembled MAGs

--- a/workflow/scripts/snakemake_antismash_cohort.sh
+++ b/workflow/scripts/snakemake_antismash_cohort.sh
@@ -30,11 +30,14 @@ thread_count=$1;
 ls results/MAGs/PerCohort/*/*_minContig1500.*.fa | while read file; do
 	# first designate variables & directories
 	parentname="$(basename "$(dirname "$file")")"; # this gets the parent/cohort directory name
-	mkdir -p results/BGCs/AntiSMASH/PerCohort/${parentname}; #create an output directory
+	full_file="${file##*/}"; #this line removes the path before the file name
+	file_base="${full_file%.*}"; #this line removes the file extension .fa
+	file_base2="${file_base//./_}"; # replace periods with underscores
+	mkdir -p results/BGCs/AntiSMASH/PerCohort/${parentname}/${file_base2}; #create an output directory
 	# now run AntiSMASH
 	apptainer exec workflow/containers/env-antismash.sif antismash --taxon bacteria --cpus $thread_count \
 	--minlength 30 --no-abort-on-invalid-records --genefinding-tool prodigal-m \
-	--output-dir results/BGCs/AntiSMASH/PerCohort/${parentname} \
+	--output-dir results/BGCs/AntiSMASH/PerCohort/${parentname}/${file_base2} \
 	--fullhmmer --pfam2go $file;
 done;
 

--- a/workflow/scripts/snakemake_antismash_sample.sh
+++ b/workflow/scripts/snakemake_antismash_sample.sh
@@ -33,13 +33,13 @@ ls results/MAGs/PerSample/*/*/*_minContig1500.*.fa | while read file; do
 	grandparent_dir="${parentname##*/}"; # this gets the grandparent/cohort directory name
 	full_file="${file##*/}"; #this line removes the path before the file name
 	file_base="${full_file%.*}"; #this line removes the file extension .fa
-	file_base2="${file_base%.*}"; #this line removes the file extension .1
-	file_base_id="${file_base2%_metabat2_minContig1500}"; #this removes the "_metabat2_minContig1500" substring
-	mkdir -p results/BGCs/AntiSMASH/PerSample/${grandparent_dir}/${file_base_id}; #create an output directory
+	file_base2="${file_base//./_}"; # replace periods with underscores
+	# ref: https://stackoverflow.com/questions/54964666/bash-shell-reworking-variable-replace-dots-by-underscore
+	mkdir -p results/BGCs/AntiSMASH/PerSample/${grandparent_dir}/${file_base2}; #create an output directory
 	# now run AntiSMASH
 	apptainer exec workflow/containers/env-antismash.sif antismash --taxon bacteria --cpus $thread_count \
 	--minlength 30 --no-abort-on-invalid-records --genefinding-tool prodigal-m \
-	--output-dir results/BGCs/AntiSMASH/PerSample/${grandparent_dir}/${file_base_id} \
+	--output-dir results/BGCs/AntiSMASH/PerSample/${grandparent_dir}/${file_base2} \
 	--fullhmmer --pfam2go $file;
 done;
 


### PR DESCRIPTION
- Lowered minimum MAG size for MetaBat; added argument to `config.yaml` to enable command-line modification
- Fixed issue with AntiSmash scripts