### PR TITLE
SPOT-BGC v3.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,24 @@ The SPOT-BGC pipeline performs the following on input metagenomic FASTQ reads:
 11. Taxonomic assignments of the MAGs: CheckM
 12. BGC predictions: GECCO, AntiSMASH
 
+```mermaid
+flowchart TD
+    X(Set up working directory with snakemake_setup.sh) --> A[Read QC]
+    A --> B[Quality Trimming]
+    B --> C[Human Read Filtration]
+    C --> D[Read Count Normalization]
+    D --> E[>= 100k Reads Filtration]
+    E --> F{Per-Cohort Assembly}
+    E --> G{Per-Sample Assembly}
+    F --> H[Human Contig Elimination]
+    G --> H[Human Contig Elimination]
+    H --> I[Binning Contigs into MAGs]
+    I --> J[MAG QC]
+    J --> K[Taxonomic Assignment]
+    K --> L[BGC Prediction]
+    L --> |Optional| M(Clean working directory with snakemake_cleanup.sh)
+```
+
 
 ## Dependencies
 
@@ -172,12 +190,15 @@ snakemake --executor slurm --jobs 10 --profile=profiles/slurm --use-singularity 
 
 ### Current release version
 
-Second major update, 2025.08.02: Build 3.0.0
- - Ensured SLURM HPC environmental compliance & functionality.
-   - A change made for version 2.0.0 has been rolled back, and the `snakemake_setup.sh` script must once again be run by the user _prior_ to running the SPOT-BGC pipeline. This was done due to circumvent complications with running Snakemake in an HPC environment.
- - The configuration file at `config/config.yaml` includes some additional parameters that can be modified from the command line beyond program thread counts, such as the memory allocation to BBnorm.
- - Usage notes/disclaimers:
-   - At this stage, most users will need to modify the `config.yaml` file manually in order to change the reference genome, as well as modify the `Snakefile` or `bash` scripts manually in order to change the settings/arguments of the various programs.
+Wildcard patch & minor updates, 2025.10.22: Build 3.1.0
+ - Patch wildcard usage: Resolved issues relating to wildcard inconsistency that was causing the pipeline to occasionally crash
+   - I received help from StackOverflow contributors in this process: 
+     - Second Question (which enabled me to track down the true source of the errors): https://stackoverflow.com/questions/79792470/how-can-i-use-wildcard-paths-from-a-pandas-dataframe-as-required-rule-inputs-and/79792740#79792740
+     - First Question: https://stackoverflow.com/questions/79790165/snakemake-wildcard-issues-using-touch-to-avoid-premature-pipeline-progression
+ - Quality of life updates: 
+   - GECCO: writing out GFF results files by default for easier parsing
+   - Working directory cleaning: The `workflow/scripts/snakemake_cleanup.sh` script can now be used to clean the SPOT-BGC working directory prior to rerunning the pipeline (i.e., removing old results & log files, deleting the files in `resources/RawData/` etc.)
+   - Additions to `config.yaml` file: MetaSPAdes timeout time, domain selection for CheckM taxonomy
 
 ### Ongoing work for future versions
 
@@ -185,6 +206,13 @@ Potential future plans (no set date):
  - Branching pipeline: Allow user to choose which programs in the later parts of the pipeline actually need to be run.
 
 ### Logs of previous major updates
+
+Second major update, 2025.08.02: Build 3.0.0
+ - Ensured SLURM HPC environmental compliance & functionality.
+   - A change made for version 2.0.0 has been rolled back, and the `snakemake_setup.sh` script must once again be run by the user _prior_ to running the SPOT-BGC pipeline. This was done due to circumvent complications with running Snakemake in an HPC environment.
+ - The configuration file at `config/config.yaml` includes some additional parameters that can be modified from the command line beyond program thread counts, such as the memory allocation to BBnorm.
+ - Usage notes/disclaimers:
+   - At this stage, most users will need to modify the `config.yaml` file manually in order to change the reference genome, as well as modify the `Snakefile` or `bash` scripts manually in order to change the settings/arguments of the various programs.
 
 Minor update, 2025.01.18: Build 2.0.1
  - Hotfix for AntiSMASH functionality in the case of multiple MAGs predicted from an assembly

--- a/README.md
+++ b/README.md
@@ -6,8 +6,9 @@ _A Snakemake Pipeline to Output meTagenomics-derived Biosynthetic Gene Clusters_
 
 Author: Vi Varga
 
+Current version: 3.1.0
 
-Last Major Update: 2025.08.02
+Last Major Update: 2025.10.22
 
 
 ## Introduction 

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -40,8 +40,12 @@ threads_antismash: 5
 
 # additional program settings
 
+metaspades_timeout: '6h'
+
 metabat_bin_size: 10000
 
 bbnorm_memory: '-Xmx40G'
 
 memory_maximum: 60000
+
+checkm_domain: 'Bacteria'

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -1,9 +1,9 @@
 # Snakefile for SPOT-BGC workflow pipeline
 
 # Author: Vi Varga
-# Last edit date: 2025.07.30
+# Last edit date: 2025.10.22
 
-# SPOT-BGC v.3.0.0
+# SPOT-BGC v.3.1.0
 # originally written in PyCharm Community Edition version 2024.3.1.1
 # SLURM functionality confirmed in Visual Studio Code 1.102.3
 # developed using Snakemake version 8.27.1
@@ -91,7 +91,7 @@ rule all:
 		'logs/MetaSPAdes/MetaSPAdes_PE_completion.txt',
 		expand('logs/MetaSPAdes/{cohort_norm_sample}_read_assembly_se_log.txt',
 			cohort_norm_sample=fq_SE_names_df.CohortSample,allow_missing=True),
-		'logs/MetaSPAdes/MetaSPAdes_PE_completion.txt',
+		'logs/MetaSPAdes/MetaSPAdes_SE_completion.txt',
 		'results/Assembly/PerCohort/MEGAHIT_Tracking_SE.txt',
 		'results/Assembly/PerCohort/MEGAHIT_Tracking_PE.txt',
 		'results/Assembly/PerCohort/MEGAHIT_Tracking_PEandSE.txt',
@@ -166,9 +166,9 @@ rule multiqc_1:
 
 # quality trimming of FASTQ files
 # rule trim_files_pe handles trimming paired-end reads
-# this rule and preceeding should be possible to skip
 rule trim_files_pe:
 	input:
+		# lambda wildcards: expand("{species}_{rep}", species=[wildcards.species], rep=get_reps(wildcards.species))
 		fq1 = "resources/RawData/{cohort_id}/{sample_name,[A-Za-z0-9]+}/{sample_name,[A-Za-z0-9]+}_1.fastq",
 		fq2 = "resources/RawData/{cohort_id}/{sample_name,[A-Za-z0-9]+}/{sample_name,[A-Za-z0-9]+}_2.fastq"
 	output:
@@ -195,7 +195,6 @@ rule trim_files_pe:
 		"""
 
 # rule trim_files_se handles trimming paired-end reads
-# this rule and preceeding should be possible to skip
 rule trim_files_se:
 	input:
 		fq_se = "resources/RawData/{cohort_id}/{sample_name,[A-Za-z0-9]+}/{sample_name,[A-Za-z0-9]+}.fastq"
@@ -255,7 +254,7 @@ rule index_genome:
 	output:
 		multiext("resources/Ref/GCA_000001405__29_GRCh38__p14_masked",
 			".1.bt2",	".2.bt2", ".3.bt2", ".4.bt2",
-			".rev.1.bt2", ".rev.2.bt2"),
+			".rev.1.bt2", ".rev.2.bt2")
 	threads: config['threads_bowtie_index']
 	log:
 		"logs/Bowtie2/genome_index_log.txt"
@@ -271,8 +270,8 @@ rule index_genome:
 rule map_reads_pe:
 	input:
 		idx = rules.index_genome.output,
-		trimmed_fq1 = lambda wildcards: fq_R1_names_df.loc[wildcards.cohort_with_sample, 'Location_Trim'],
-		trimmed_fq2 = lambda wildcards: fq_R2_names_df.loc[wildcards.cohort_with_sample, 'Location_Trim']
+		trimmed_fq1 = lambda wildcards: f"results/Trimmomatic/{fq_R1_names_df.loc[wildcards.cohort_with_sample, 'CohortSample']}.1.fastq",
+		trimmed_fq2 = lambda wildcards: f"results/Trimmomatic/{fq_R2_names_df.loc[wildcards.cohort_with_sample, 'CohortSample']}.2.fastq"
 	output:
 		human_reads = "results/DataNonHuman/NonHumanOG/{cohort_with_sample}_human_map.sam",
 		mapping_metric_reads = "results/DataNonHuman/NonHumanOG/{cohort_with_sample}_Metrics.txt",
@@ -299,7 +298,7 @@ rule map_reads_pe:
 rule map_reads_se:
 	input:
 		idx = rules.index_genome.output,
-		trimmed_fqse = lambda wildcards: fq_SE_names_df.loc[wildcards.cohort_with_sample, 'Location_Trim']
+		trimmed_fqse = lambda wildcards: f"results/Trimmomatic/{fq_SE_names_df.loc[wildcards.cohort_with_sample, 'CohortSample']}.SE.fastq"
 	output:
 		human_reads = "results/DataNonHuman/NonHumanOG/{cohort_with_sample}_human_map.sam",
 		mapping_metric_reads = "results/DataNonHuman/NonHumanOG/{cohort_with_sample}_Metrics.txt",
@@ -324,20 +323,21 @@ rule map_reads_se:
 # rule bbnorm_pe normalizes PE reads
 rule bbnorm_pe:
 	input:
-		mapped_fq1 = lambda wildcards: fq_R1_names_df.loc[wildcards.cohort_mapped_with_sample, 'Location_NonHuman'],
-		mapped_fq2 = lambda wildcards: fq_R2_names_df.loc[wildcards.cohort_mapped_with_sample, 'Location_NonHuman']
+		mapped_fq1 = lambda wildcards: f"results/DataNonHuman/NonHumanOG/{fq_R1_names_df.loc[wildcards.cohort_with_sample,'CohortSample']}_NON-human_map.1.fq",
+		mapped_fq2 = lambda wildcards: f"results/DataNonHuman/NonHumanOG/{fq_R2_names_df.loc[wildcards.cohort_with_sample,'CohortSample']}_NON-human_map.2.fq"
 	output:
-		input_kmers = "results/DataNonHuman/BBNorm_Reads/{cohort_mapped_with_sample}_NON-human_map_input_kmers.png",
-		output_kmers = "results/DataNonHuman/BBNorm_Reads/{cohort_mapped_with_sample}_NON-human_map_output_kmers.png",
-		normalized_fq1 = "results/DataNonHuman/BBNorm_Reads/{cohort_mapped_with_sample}_norm.1.fq",
-		normalized_fq2 = "results/DataNonHuman/BBNorm_Reads/{cohort_mapped_with_sample}_norm.2.fq"
+		input_kmers = "results/DataNonHuman/BBNorm_Reads/{cohort_with_sample}_NON-human_map_input_kmers.png",
+		output_kmers = "results/DataNonHuman/BBNorm_Reads/{cohort_with_sample}_NON-human_map_output_kmers.png",
+		normalized_fq1 = "results/DataNonHuman/BBNorm_Reads/{cohort_with_sample}_norm.1.fq",
+		normalized_fq2 = "results/DataNonHuman/BBNorm_Reads/{cohort_with_sample}_norm.2.fq",
+		pe_completion = "results/DataNonHuman/BBNorm_Reads/{cohort_with_sample}.pe.COMPLETE"
 	threads: config['threads_bbnorm']
 	resources:
 		mem_mb = config['memory_maximum']
 	params:
 		memory_alloc = config['bbnorm_memory']
 	log:
-		"logs/BBnorm/{cohort_mapped_with_sample}_read_mapping_log.txt"
+		"logs/BBnorm/{cohort_with_sample}_read_mapping_log.txt"
 	shell:
 		"""
 		apptainer exec workflow/containers/bbtools.sif /bbmap/bbnorm.sh {params.memory_alloc} \
@@ -345,16 +345,19 @@ rule bbnorm_pe:
 		out={output.normalized_fq1} out2={output.normalized_fq2} \
 		target=80 min=3 threads={threads} \
 		hist={output.input_kmers} histout={output.output_kmers}
+		
+		touch {output.pe_completion}
 		"""
 
 # rule bbnorm_se normalizes SE reads
 rule bbnorm_se:
 	input:
-		mapped_fqse = lambda wildcards: fq_SE_names_df.loc[wildcards.cohort_with_sample, 'Location_NonHuman']
+		mapped_fqse = lambda wildcards: f"results/DataNonHuman/NonHumanOG/{fq_SE_names_df.loc[wildcards.cohort_with_sample,'CohortSample']}_NON-human_map.SE.fq"
 	output:
 		input_kmers = "results/DataNonHuman/BBNorm_Reads/{cohort_with_sample}_NON-human_map_input_kmers.png",
 		output_kmers = "results/DataNonHuman/BBNorm_Reads/{cohort_with_sample}_NON-human_map_output_kmers.png",
-		normalized_fqse = "results/DataNonHuman/BBNorm_Reads/{cohort_with_sample}_norm.SE.fq"
+		normalized_fqse = "results/DataNonHuman/BBNorm_Reads/{cohort_with_sample}_norm.SE.fq",
+		se_completion = "results/DataNonHuman/BBNorm_Reads/{cohort_with_sample}.se.COMPLETE"
 	threads: config['threads_bbnorm']
 	resources:
 		mem_mb = config['memory_maximum']
@@ -367,6 +370,8 @@ rule bbnorm_se:
 		apptainer exec workflow/containers/bbtools.sif /bbmap/bbnorm.sh {params.memory_alloc} \
 		in={input.mapped_fqse} out={output.normalized_fqse} threads={threads} \
 		target=80 min=3 hist={output.input_kmers} histout={output.output_kmers}
+		
+		touch {output.se_completion}
 		"""
 
 
@@ -374,12 +379,16 @@ rule bbnorm_se:
 rule filt_100k:
 	input:
 		expand("results/DataNonHuman/BBNorm_Reads/{cohort_with_sample}_norm.1.fq",
-			cohort_with_sample = fq_R1_names_df.CohortSample),
+			cohort_with_sample = fq_R1_names_df["CohortSample"]),
 		expand("results/DataNonHuman/BBNorm_Reads/{cohort_with_sample}_norm.2.fq",
-			cohort_with_sample = fq_R1_names_df.CohortSample),
+			cohort_with_sample = fq_R1_names_df["CohortSample"]),
 		expand("results/DataNonHuman/BBNorm_Reads/{cohort_with_sample}_norm.SE.fq",
-			cohort_with_sample = fq_SE_names_df.CohortSample),
-		filtering_script = 'workflow/scripts/snakemake_100k_filt.sh',
+			cohort_with_sample = fq_SE_names_df["CohortSample"]),
+		expand("results/DataNonHuman/BBNorm_Reads/{cohort_with_sample}.pe.COMPLETE",
+			cohort_with_sample = fq_R1_names_df["CohortSample"]),
+		expand("results/DataNonHuman/BBNorm_Reads/{cohort_with_sample}.se.COMPLETE",
+			cohort_with_sample = fq_SE_names_df["CohortSample"]),
+		filtering_script = 'workflow/scripts/snakemake_100k_filt.sh'
 	log:
 		filt_100k_log = 'logs/100k_filt.txt'
 	output:
@@ -397,12 +406,14 @@ rule assembly_perSample_pe:
 		'logs/MetaSPAdes/MetaSPAdes_PE_completion.txt'
 	resources:
 		mem_mb = config['memory_maximum']
+	params:
+		metaspades_timout_time = config['metaspades_timeout']
 	log:
 		expand("logs/MetaSPAdes/{cohort_norm_sample}_read_assembly_pe_log.txt",
 			cohort_norm_sample=fq_R1_names_df.CohortSample,allow_missing=True)
 	threads: config['threads_metaspades']
 	shell:
-		"bash workflow/scripts/snakemake_metaspades_pe_safe.sh {threads}"
+		"bash workflow/scripts/snakemake_metaspades_pe_safe.sh {threads} {params.metaspades_timout_time}"
 
 # rule assembly_perSample_se performs per-sample assembly with MetaSPAdes
 rule assembly_perSample_se:
@@ -412,12 +423,14 @@ rule assembly_perSample_se:
 		'logs/MetaSPAdes/MetaSPAdes_SE_completion.txt'
 	resources:
 		mem_mb = config['memory_maximum']
+	params:
+		metaspades_timout_time = config['metaspades_timeout']
 	log:
 		expand("logs/MetaSPAdes/{cohort_norm_sample}_read_assembly_se_log.txt",
 			cohort_norm_sample=fq_SE_names_df.CohortSample,allow_missing=True)
 	threads: config['threads_metaspades']
 	shell:
-		"bash workflow/scripts/snakemake_metaspades_se_safe.sh {threads}"
+		"bash workflow/scripts/snakemake_metaspades_se_safe.sh {threads} {params.metaspades_timout_time}"
 
 
 # rule assembly_perCohort_peANDse performs per-cohort paired- & single-end assembly with MEGAHIT
@@ -472,7 +485,7 @@ rule assembly_perCohort_se:
 # should be possible to skip all previous steps
 rule kraken_copyDB:
 	output:
-		kraken_cp_log = 'logs/AssemblyNonHuman_cp_db.txt',
+		kraken_cp_log = 'logs/AssemblyNonHuman_cp_db.txt'
 	shell:
 		"""
 		apptainer exec workflow/containers/env-kraken2db.sif cp -r /kraken2_human_db/ resources/ \
@@ -573,8 +586,10 @@ rule taxa_perCohort:
 	log:
 		"logs/Taxonomy/PerCohort/checkm_taxa_cohort.log"
 	threads: config['threads_checkm']
+	params:
+		checkm_search_domain = config['checkm_domain']
 	shell:
-		"bash workflow/scripts/snakemake_checkm_taxa_cohort.sh {threads}"
+		"bash workflow/scripts/snakemake_checkm_taxa_cohort.sh {threads} {params.checkm_search_domain}"
 
 # rule taxa_perCohort should use Metaphlan to assign MAGs to taxa in the per-cohort assemblies
 rule taxa_perSample:
@@ -583,8 +598,10 @@ rule taxa_perSample:
 	log:
 		"logs/Taxonomy/PerSample/checkm_taxa_sample.log"
 	threads: config['threads_checkm']
+	params:
+		checkm_search_domain = config['checkm_domain']
 	shell:
-		"bash workflow/scripts/snakemake_checkm_taxa_sample.sh {threads}"
+		"bash workflow/scripts/snakemake_checkm_taxa_sample.sh {threads} {params.checkm_search_domain}"
 
 
 # BGC predictions

--- a/workflow/scripts/snakemake_100k_filt.sh
+++ b/workflow/scripts/snakemake_100k_filt.sh
@@ -55,5 +55,5 @@ FullFileNamesTrimmed.txt noexclusion,noneexcluded;
 # navigate back up to the main directory
 cd ../../..;
 # create an output file that marks script completion
-mkdir logs/completion;
+mkdir -p logs/completion;
 touch logs/completion/100k_filt__COMPLETE.txt;

--- a/workflow/scripts/snakemake_checkm_taxa_cohort.sh
+++ b/workflow/scripts/snakemake_checkm_taxa_cohort.sh
@@ -11,9 +11,9 @@
 # perform taxonomic profiling. 
 # 
 # Usage: 
-# 	./snakemake_checkm_taxa_cohort.sh threads
+# 	./snakemake_checkm_taxa_cohort.sh threads checkm_domain_id
 # 	OR
-# 	bash snakemake_checkm_taxa_cohort.sh threads
+# 	bash snakemake_checkm_taxa_cohort.sh threads checkm_domain_id
 # 
 # 	Note that this script is intended to be run from the parent SPOT-BGC-working/ directory!
 #
@@ -23,6 +23,8 @@
 # take thread count as positional argument
 # ref: https://www.baeldung.com/linux/use-command-line-arguments-in-bash-script
 thread_count=$1;
+# take domain to use for CheckM taxonomy
+checkm_domain_id=$2;
 
 
 ### Running CheckM
@@ -38,7 +40,7 @@ ls results/MAGs/PerCohort/*/*_metabat2_minContig1500.1.fa | while read file; do
 	mkdir -p results/MAG_QC/PerCohort/${parentname}; #create an output directory
 	# now run CheckM
 	apptainer exec workflow/containers/mag_assembly_qc.sif checkm taxonomy_wf \
-	-x fa -t $1 domain Bacteria results/MAGs/PerCohort/${parentname} \
+	-x fa -t $thread_count domain $checkm_domain_id results/MAGs/PerCohort/${parentname} \
 	results/Taxonomy/PerCohort/${parentname}; 
 done;
 

--- a/workflow/scripts/snakemake_checkm_taxa_sample.sh
+++ b/workflow/scripts/snakemake_checkm_taxa_sample.sh
@@ -11,9 +11,9 @@
 # perform taxonomic profiling. 
 # 
 # Usage: 
-# 	./snakemake_checkm_taxa_sample.sh threads
+# 	./snakemake_checkm_taxa_sample.sh threads checkm_domain_id
 # 	OR
-# 	bash snakemake_checkm_taxa_sample.sh threads
+# 	bash snakemake_checkm_taxa_sample.sh threads checkm_domain_id
 # 
 # 	Note that this script is intended to be run from the parent SPOT-BGC/ directory!
 #
@@ -23,6 +23,8 @@
 # take thread count as positional argument
 # ref: https://www.baeldung.com/linux/use-command-line-arguments-in-bash-script
 thread_count=$1;
+# take domain to use for CheckM taxonomy
+checkm_domain_id=$2;
 
 
 ### Running CheckM
@@ -43,7 +45,7 @@ ls results/MAGs/PerSample/*/*/*_metabat2_minContig1500.1.fa | while read file; d
 	mkdir -p results/Taxonomy/PerSample/${grandparent_dir}/${file_base_id}; #create an output directory
 	# now run CheckM
 	apptainer exec workflow/containers/mag_assembly_qc.sif checkm taxonomy_wf \
-	-x fa -t $1 domain Bacteria results/MAGs/PerSample/${grandparent_dir}/${file_base_id} \
+	-x fa -t $thread_count domain $checkm_domain_id results/MAGs/PerSample/${grandparent_dir}/${file_base_id} \
 	results/Taxonomy/PerSample/${grandparent_dir}/${file_base_id}; 
 done;
 

--- a/workflow/scripts/snakemake_metaspades_pe_safe.sh
+++ b/workflow/scripts/snakemake_metaspades_pe_safe.sh
@@ -12,9 +12,9 @@
 # run will be cancelled, and MEGAHIT will be run on the sample, instead.
 # 
 # Usage: 
-# 	./snakemake_metaspades_pe_safe.sh threads
+# 	./snakemake_metaspades_pe_safe.sh threads timeout_val
 # 	OR
-# 	bash snakemake_metaspades_pe_safe.sh threads
+# 	bash snakemake_metaspades_pe_safe.sh threads timeout_val
 # 
 # 	Note that this script is intended to be run from the parent SPOT-BGC/ directory!
 #
@@ -26,6 +26,8 @@
 # take thread count as positional argument
 # ref: https://www.baeldung.com/linux/use-command-line-arguments-in-bash-script
 thread_count=$1;
+# time to wait for timeout
+timeout_val=$2;
 
 
 # creating the completion tracking file
@@ -55,7 +57,7 @@ if [ -s results/Assembly/PerSample/Assembly_INCOMPLETE_PE.TXT ]; then
 		file_base_id="${file_base2%_norm}"; #this removes the "_norm" substring
 		mkdir -p results/Assembly/PerSample/${parentname}/${file_base_id}; #create an output directory
 		# now run the program, with a time limit of 6 hours for successful assembly
-		timeout 6h apptainer exec workflow/containers/metagenome_assembly.sif metaspades.py \
+		timeout $timeout_val apptainer exec workflow/containers/metagenome_assembly.sif metaspades.py \
 		-1 $file -2 results/DataNonHuman/100k_Filt/${parentname}/${file_base_id}_norm.2.fq \
 		--checkpoints all --threads $thread_count \
 		-o results/Assembly/PerSample/${parentname}/${file_base_id}/;

--- a/workflow/scripts/snakemake_metaspades_se_safe.sh
+++ b/workflow/scripts/snakemake_metaspades_se_safe.sh
@@ -12,9 +12,9 @@
 # run will be cancelled, and MEGAHIT will be run on the sample, instead.
 # 
 # Usage: 
-# 	./snakemake_metaspades_se_safe.sh threads
+# 	./snakemake_metaspades_se_safe.sh threads timeout_val
 # 	OR
-# 	bash snakemake_metaspades_se_safe.sh threads
+# 	bash snakemake_metaspades_se_safe.sh threads timeout_val
 # 
 # 	Note that this script is intended to be run from the parent SPOT-BGC/ directory!
 #
@@ -24,6 +24,8 @@
 # take thread count as positional argument
 # ref: https://www.baeldung.com/linux/use-command-line-arguments-in-bash-script
 thread_count=$1;
+# time to wait for timeout
+timeout_val=$2;
 
 
 # creating the completion tracking file
@@ -53,7 +55,7 @@ if [ -s results/Assembly/PerSample/Assembly_INCOMPLETE_SE.TXT ]; then
 		file_base_id="${file_base2%_norm}"; #this removes the "_norm" substring
 		mkdir -p results/Assembly/PerSample/${parentname}/${file_base_id}; #create an output directory
 		# now run the program
-		timeout 6h apptainer exec workflow/containers/metagenome_assembly.sif spades.py \
+		timeout $timeout_val apptainer exec workflow/containers/metagenome_assembly.sif spades.py \
 		-s $file --checkpoints all --threads $thread_count \
 		-o results/Assembly/PerSample/${parentname}/${file_base_id};
 		# check exit status of each sample


### PR DESCRIPTION
Wildcard patch & minor updates, 2025.10.22: Build 3.1.0
 - Patch wildcard usage: Resolved issues relating to wildcard inconsistency that was causing the pipeline to occasionally crash
   - I received help from StackOverflow contributors in this process: 
     - Second Question (which enabled me to track down the true source of the errors): https://stackoverflow.com/questions/79792470/how-can-i-use-wildcard-paths-from-a-pandas-dataframe-as-required-rule-inputs-and/79792740#79792740
     - First Question: https://stackoverflow.com/questions/79790165/snakemake-wildcard-issues-using-touch-to-avoid-premature-pipeline-progression
 - Quality of life updates: 
   - GECCO: writing out GFF results files by default for easier parsing
   - Working directory cleaning: The `workflow/scripts/snakemake_cleanup.sh` script can now be used to clean the SPOT-BGC working directory prior to rerunning the pipeline (i.e., removing old results & log files, deleting the files in `resources/RawData/` etc.)
   - Additions to `config.yaml` file: MetaSPAdes timeout time, domain selection for CheckM taxonomy